### PR TITLE
商品一覧表示機能

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,7 +1,7 @@
 class ItemsController < ApplicationController
   before_action :authenticate_user!, except: [:index, :show]
   def index
-    @items = Item.includes(:user).order("created_at DESC")
+    @items = Item.includes(:user).order('created_at DESC')
   end
 
   def new

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,6 +1,7 @@
 class ItemsController < ApplicationController
   before_action :authenticate_user!, except: [:index, :show]
   def index
+    @items = Item.includes(:user).order("created_at DESC")
   end
 
   def new

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -125,6 +125,7 @@
     <h2 class='title'>ピックアップカテゴリー</h2>
     <%= link_to '新規投稿商品', new_item_path, class: "subtitle" %>
     <ul class='item-lists'>
+    <% if @items.exists? %>
     <% @items.each do |item| %>
       <li class='list'>
         <%= link_to "#" do %>
@@ -144,7 +145,8 @@
             <%= item.name %>
           </h3>
           <div class='item-price'>
-            <span><%= item.price %>円<br><%= item.shipping_fee_status_id %></span>
+            <span><%= item.price %>円<br><%= item.shipping_fee_status.name %></span> 
+            
             <div class='star-btn'>
               <%= image_tag "star.png", class:"star-icon" %>
               <span class='star-count'>0</span>
@@ -153,6 +155,7 @@
         </div>
         <% end %>
       </li>
+      <% end %>
       <% end %>
       <%# 商品がない場合のダミー %>
       <%# 商品がある場合は表示されないようにしましょう %>

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -156,7 +156,7 @@
       <% end %>
       <%# 商品がない場合のダミー %>
       <%# 商品がある場合は表示されないようにしましょう %>
-      <% if  item = nil %>
+      <% if  @items.empty?  %>
       <li class='list'>
         <%= link_to '#' do %>
         <%= image_tag "https://s3-ap-northeast-1.amazonaws.com/mercarimaster/uploads/captured_image/content/10/a004.png", class: "item-img" %>

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -123,7 +123,7 @@
   <%# 商品一覧 %>
   <div class='item-contents'>
     <h2 class='title'>ピックアップカテゴリー</h2>
-    <%= link_to '新規投稿商品', "#", class: "subtitle" %>
+    <%= link_to '新規投稿商品', new_item_path, class: "subtitle" %>
     <ul class='item-lists'>
     <% @items.each do |item| %>
       <li class='list'>

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -124,14 +124,14 @@
   <div class='item-contents'>
     <h2 class='title'>ピックアップカテゴリー</h2>
     <%= link_to '新規投稿商品', "#", class: "subtitle" %>
+    <% @items.each do |item| %>
     <ul class='item-lists'>
-
-      <%# 商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
       <li class='list'>
         <%= link_to "#" do %>
         <div class='item-img-content'>
-          <%= image_tag "item-sample.png", class: "item-img" %>
-
+          <% if item.image.attached? %>
+          <%=image_tag item.image, class: "item-img" %>
+          <% end %>
           <%# 商品が売れていればsold outを表示しましょう %>
           <div class='sold-out'>
             <span>Sold Out!!</span>
@@ -141,10 +141,10 @@
         </div>
         <div class='item-info'>
           <h3 class='item-name'>
-            <%= "商品名" %>
+            <%= item.name %>
           </h3>
           <div class='item-price'>
-            <span><%= "販売価格" %>円<br><%= '配送料負担' %></span>
+            <span><%= item.price %>円<br><%= item.shipping_fee_status_id %></span>
             <div class='star-btn'>
               <%= image_tag "star.png", class:"star-icon" %>
               <span class='star-count'>0</span>
@@ -153,7 +153,6 @@
         </div>
         <% end %>
       </li>
-      <%# //商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
 
       <%# 商品がない場合のダミー %>
       <%# 商品がある場合は表示されないようにしましょう %>
@@ -177,6 +176,7 @@
       <%# //商品がある場合は表示されないようにしましょう %>
       <%# /商品がない場合のダミー %>
     </ul>
+    <% end %>
   </div>
   <%# /商品一覧 %>
 </div>

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -124,8 +124,8 @@
   <div class='item-contents'>
     <h2 class='title'>ピックアップカテゴリー</h2>
     <%= link_to '新規投稿商品', "#", class: "subtitle" %>
-    <% @items.each do |item| %>
     <ul class='item-lists'>
+    <% @items.each do |item| %>
       <li class='list'>
         <%= link_to "#" do %>
         <div class='item-img-content'>
@@ -153,9 +153,10 @@
         </div>
         <% end %>
       </li>
-
+      <% end %>
       <%# 商品がない場合のダミー %>
       <%# 商品がある場合は表示されないようにしましょう %>
+      <% if  item = nil %>
       <li class='list'>
         <%= link_to '#' do %>
         <%= image_tag "https://s3-ap-northeast-1.amazonaws.com/mercarimaster/uploads/captured_image/content/10/a004.png", class: "item-img" %>
@@ -173,10 +174,10 @@
         </div>
         <% end %>
       </li>
+      <% end %>
       <%# //商品がある場合は表示されないようにしましょう %>
       <%# /商品がない場合のダミー %>
     </ul>
-    <% end %>
   </div>
   <%# /商品一覧 %>
 </div>

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe Item, type: :model do
           expect(@item).to be_valid
         end
       end
-      
+
       context '商品が保存できない場合' do
         it '商品画像を1枚つけることが必須であること' do
           @item.image = nil


### PR DESCRIPTION
画像が表示されており、画像がリンク切れなどになっていないこと
出品した商品の一覧表示ができていること
上から、出品された日時が新しい順に表示されること
「画像/価格/商品名」の3つの情報について表示できていること
売却済みの商品は、画像上に「sold out」の文字が表示されるようになっていること
https://gyazo.com/073399d46d6a3ae1eec910715f547e25
ログアウト状態のユーザーでも、商品一覧表示ページを見ることができること
https://gyazo.com/664348250ada342bcde201142d58a28e

よろしくお願いします